### PR TITLE
update http://ror.org/facts link to a new ROR page

### DIFF
--- a/datatypes/ROR_ID.md
+++ b/datatypes/ROR_ID.md
@@ -12,6 +12,6 @@ The datatype that represents the [ROR](https://ror.org/) identifier.
 
 ---
 ## References
-<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.org/facts/
+<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.readme.io/docs/identifier
 
 <a name="fn2">\[2\]</a> *ISO/IEC 7064:2003. Information technology — Security techniques — Check character systems.* International Standards Organization.

--- a/datatypes/ROR_ID.md
+++ b/datatypes/ROR_ID.md
@@ -12,6 +12,6 @@ The datatype that represents the [ROR](https://ror.org/) identifier.
 
 ---
 ## References
-<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.readme.io/docs/identifier
+<a name="fn1">\[1\]</a> *Identifier*. ROR. Available from https://ror.readme.io/docs/identifier
 
 <a name="fn2">\[2\]</a> *ISO/IEC 7064:2003. Information technology — Security techniques — Check character systems.* International Standards Organization.

--- a/entities/ROR_Identifier.md
+++ b/entities/ROR_Identifier.md
@@ -19,4 +19,4 @@ A ROR Identifier can only [be assigned](../entities/Agent_Identifier.md#user-con
 
 ---
 ## References
-<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.org/facts/
+<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.readme.io/docs/identifier

--- a/entities/ROR_Identifier.md
+++ b/entities/ROR_Identifier.md
@@ -19,4 +19,4 @@ A ROR Identifier can only [be assigned](../entities/Agent_Identifier.md#user-con
 
 ---
 ## References
-<a name="fn1">\[1\]</a> *Facts*. ROR. Available from https://ror.readme.io/docs/identifier
+<a name="fn1">\[1\]</a> *Identifier*. ROR. Available from https://ror.readme.io/docs/identifier


### PR DESCRIPTION
Described in issue #33. This PR updates the link to a new page at ROR.org; https://ror.readme.io/docs/identifier .